### PR TITLE
I'm using Ubuntu 12.04LTS and ran into some build and test problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ clean:
 rebuild: clean default
 
 seccure: seccure.o numtheory.o ecc.o serialize.o protocol.o curves.o aes256ctr.o
-	$(CC) $(CFLAGS) -o seccure -lgcrypt seccure.o numtheory.o ecc.o \
-	curves.o serialize.o protocol.o aes256ctr.o
+	$(CC) $(CFLAGS) -o seccure seccure.o numtheory.o ecc.o \
+	curves.o serialize.o protocol.o aes256ctr.o -lgcrypt
 	strip seccure
 
 seccure.o: seccure.c

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,11 +1,11 @@
 SECCURE-PATH = "../"
-SECCURE-KEY = $(SECCURE-PATH)"seccure key"
-SECCURE-ENCRYPT = $(SECCURE-PATH)"seccure encrypt"
-SECCURE-DECRYPT = $(SECCURE-PATH)"seccure decrypt"
-SECCURE-SIGN = $(SECCURE-PATH)"seccure sign"
-SECCURE-VERIFY = $(SECCURE-PATH)"seccure verify"
-SECCURE-SIGNCRYPT = $(SECCURE-PATH)"seccure signcrypt"
-SECCURE-VERIDEC = $(SECCURE-PATH)"seccure veridec"
+SECCURE-KEY = $(SECCURE-PATH)seccure key
+SECCURE-ENCRYPT = $(SECCURE-PATH)seccure encrypt
+SECCURE-DECRYPT = $(SECCURE-PATH)seccure decrypt
+SECCURE-SIGN = $(SECCURE-PATH)seccure sign
+SECCURE-VERIFY = $(SECCURE-PATH)seccure verify
+SECCURE-SIGNCRYPT = $(SECCURE-PATH)seccure signcrypt
+SECCURE-VERIDEC = $(SECCURE-PATH)seccure veridec
 
 ENCCURVE = "p128"
 SIGCURVE = "p256"
@@ -26,8 +26,8 @@ public-signature-key: secret-signature-key
 	$(SECCURE-KEY) -c $(SIGCURVE) -F secret-signature-key -q > public-signature-key
 
 encdec-test: public-encryption-key
-	$(SECCURE-ENCRYPT) -m $(MACLEN) -i message.txt -o message.enc -- `cat public-encryption-key`
-	$(SECCURE-DECRYPT) -m $(MACLEN) -c $(ENCCURVE) -i message.enc -o message.aux -F secret-encryption-key
+	$(SECCURE-ENCRYPT) -m $(MACLEN) `cat public-encryption-key` < message.txt > message.enc
+	$(SECCURE-DECRYPT) -m $(MACLEN) -c $(ENCCURVE) -F secret-encryption-key < message.enc > message.aux
 	cmp message.txt message.aux
 	rm -f message.enc message.aux
 
@@ -37,7 +37,7 @@ signveri-test: public-signature-key
 	rm -f message.sig
 
 signcrypt-test: public-encryption-key public-signature-key
-	$(SECCURE-SIGNCRYPT) -c $(SIGCURVE) -i message.txt -o message.enc -F secret-signature-key -- `cat public-encryption-key`
-	$(SECCURE-VERIDEC) -c $(ENCCURVE) -i message.enc -o message.aux -F secret-encryption-key -- `cat public-signature-key`
+	$(SECCURE-SIGNCRYPT) -c $(SIGCURVE) -F secret-signature-key `cat public-encryption-key` < message.txt > message.enc 
+	$(SECCURE-VERIDEC) -c $(ENCCURVE) -F secret-encryption-key `cat public-signature-key` < message.enc > message.aux
 	cmp message.txt message.aux
 	rm -f message.enc message.aux


### PR DESCRIPTION
The linker was producing a lot of undefined symbols, so I moved the -lgcrypt to the end of the link line.

I didn't dig into why I was getting core dumps with -o, but redirecting the output works for me.

Commit comments:
Make linkable on Ubuntu 12.04LTS.
Work around core dump for tests.
